### PR TITLE
Add CreatorSkills to AI Tools for Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Welcome to AI Agent Tools! This is a curated collection of AI tools, utilities, 
 * **[Jasper](https://www.jasper.ai/)** - AI content generator for marketing teams
 * **[Copy.ai](https://www.copy.ai/)** - AI-powered copywriting tool
 * **[Writesonic](https://writesonic.com/)** - AI writing assistant for content creation
+* **[CreatorSkills](https://creatorskills.co)** - Marketplace of 30+ downloadable AI skills for content creators covering YouTube scripting, sponsorship analysis, and audience growth. Works with Claude and ChatGPT.
 * **[Grammarly Business](https://www.grammarly.com/business)** - AI writing assistant for teams
 * **[Surfer SEO](https://surferseo.com/)** - AI-powered SEO tool
 * **[Frase](https://www.frase.io/)** - AI content optimization tool


### PR DESCRIPTION
Adds **[CreatorSkills](https://creatorskills.co)** to the AI Tools for Marketing section.

CreatorSkills is a marketplace of 30+ downloadable AI skills for content creators covering YouTube scripting, sponsorship analysis, and audience growth. Works with Claude and ChatGPT.

It fits alongside Jasper, Copy.ai, and Writesonic as an AI-powered content creation and marketing tool — specifically designed for content creators and marketers who want pre-built AI workflows they can install directly into their AI tools.