### PR TITLE
Add videos.social to Generative AI Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Welcome to AI Agent Tools! This is a curated collection of AI tools, utilities, 
 * **[Stable Video Diffusion](https://stability.ai/news/stable-video-diffusion-open-ai-video-model)** - Open-source video generation model
 * **[Kaiber](https://kaiber.ai/)** - AI video generator
 * **[Pictory](https://pictory.ai/)** - AI video generator from text
+* **[videos.social](https://videos.social/?utm_source=ai-agent-tools&utm_medium=directory&utm_campaign=listing-wave-d)** - Editable faceless videos from blogs, PDFs, and prompts
 * **[InVideo AI](https://invideo.io/)** - AI-powered video creation
 * **[Luma AI](https://lumalabs.ai/)** - AI video generation and editing
 * **[HeyGen](https://www.heygen.com/)** - AI video generation platform


### PR DESCRIPTION
Adds videos.social under **Generative AI Video**, next to Pictory / InVideo.

videos.social turns blogs, PDFs, and prompts into editable faceless videos (script, scenes, voiceover) rather than a locked regenerate loop. Start free — 1 render included. Packs from $10. 1 credit = 1 render.

Same product class as Pictory / InVideo. Not a duplicate.

Entry:

* **[videos.social](https://videos.social/?utm_source=ai-agent-tools&utm_medium=directory&utm_campaign=listing-wave-d)** - Editable faceless videos from blogs, PDFs, and prompts

Disclosure: submitted by the videos.social team.